### PR TITLE
WAL PoC

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -17,12 +17,49 @@ The following configuration options can be modified:
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
-  - `queue_size` (default = 5000): Maximum number of batches kept in memory before data; ignored if `enabled` is `false`;
+  - `queue_size` (default = 5000): Maximum number of batches kept in memory before data; ignored if `enabled` is `false` or WAL is enabled;
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
+  - `wal_directory` (default = empty): When set, enables Write-Ahead-Log (WAL) and specifies the directory where the log is stored. It should be unique for each exporter type
+  - `wal_sync_frequency` (default = 1s): When WAL is enabled, makes fsync with a given frequency. Set to 0 to fsync on each item being produced/consumed.
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
 
 The full list of settings exposed for this helper exporter are documented [here](factory.go).
+
+
+### WAL
+
+When `wal_directory` is set, the queue is being buffered to a disk. This has some limitations currently,
+the items that are currently being handled by a consumer are not backed by the persistent storage, which means
+that in case of a sudden shutdown, they might be lost.
+
+```
+                                                   ┌─Consumer #1─┐
+                           Truncation              │    ┌───┐    │
+                         ┌──on sync──┐        ┌───►│    │ 1 │    ├───► Success
+                         │     │     │        │    │    └───┘    │
+                         │     │     │        │    │             │
+                         │     │     │        │    └─────────────┘
+                         │     │     │        │
+ ┌─────────WAL-backed queue────┴─────┴───┐    │    ┌─Consumer #2─┐
+ │                                       │    │    │    ┌───┐    │
+ │     ┌───┐     ┌───┐ ┌───┐ ┌───┐ ┌───┐ │    │    │    │ 2 │    ├───► Permanent
+ │ n+1 │ n │ ... │ 4 │ │ 3 │ │ 2 │ │ 1 │ ├────┼───►│    └───┘    │      failure
+ │     └───┘     └───┘ └───┘ └───┘ └───┘ │    │    │             │
+ │                                       │    │    └─────────────┘
+ └───────────────────────────────────────┘    │
+    ▲              ▲                          │    ┌─Consumer #3─┐
+    │              │                          │    │    ┌───┐    │     Temporary
+    │              │                          └───►│    │ 3 │    ├───►  failure
+  write          read                              │    └───┘    │
+  index          index                             │             │         │
+    ▲                                              └─────────────┘         │
+    │                                                     ▲                │
+    │                                                     └── Retry ───────┤
+    │                                                                      │
+    │                                                                      │
+    └───────────────────────── Requeuing ◄────────── Retry limit exceeded ─┘
+```

--- a/exporter/exporterhelper/consumers_queue.go
+++ b/exporter/exporterhelper/consumers_queue.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+// This is largely based on queue.BoundedQueue and matches the subset used in the collector
+type consumersQueue interface {
+	StartConsumers(num int, callback func(item interface{}))
+	Produce(item interface{}) bool
+	Stop()
+	Size() int
+}

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -43,6 +43,19 @@ func newLogsRequest(ctx context.Context, ld pdata.Logs, pusher consumerhelper.Co
 	}
 }
 
+func newLogsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeLogsFunc) requestUnmarshaler {
+	return func(bytes []byte) (request, error) {
+		logs, err := pdata.LogsFromOtlpProtoBytes(bytes)
+		if err != nil {
+			return nil, err
+		}
+
+		// FIXME unmarshall context
+
+		return newLogsRequest(context.Background(), logs, pusher), nil
+	}
+}
+
 func (req *logsRequest) onError(err error) request {
 	var logError consumererror.Logs
 	if consumererror.AsLogs(err, &logError) {
@@ -53,6 +66,10 @@ func (req *logsRequest) onError(err error) request {
 
 func (req *logsRequest) export(ctx context.Context) error {
 	return req.pusher(ctx, req.ld)
+}
+
+func (req *logsRequest) marshall() ([]byte, error) {
+	return req.ld.ToOtlpProtoBytes()
 }
 
 func (req *logsRequest) count() int {
@@ -84,7 +101,11 @@ func NewLogsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, logger, bs)
+	be, err := newBaseExporter(cfg, logger, bs, newLogsRequestUnmarshalerFunc(pusher))
+	if err != nil {
+		return nil, err
+	}
+	be.setSignalType("logs")
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
 			obsrep: obsreport.NewExporter(obsreport.ExporterSettings{

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/collector/consumer/pdata"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/metric/metricdata"
@@ -36,10 +38,18 @@ import (
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
 
+func mockRequestUnmarshaler(mr *mockRequest) requestUnmarshaler {
+	return func(bytes []byte) (request, error) {
+		return mr, nil
+	}
+}
+
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	mockR := newMockRequest(context.Background(), 2, consumererror.Permanent(errors.New("bad data")))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), mockRequestUnmarshaler(mockR))
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -47,7 +57,6 @@ func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	mockR := newMockRequest(context.Background(), 2, consumererror.Permanent(errors.New("bad data")))
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
 		require.NoError(t, be.sender.send(mockR))
@@ -63,7 +72,8 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
 	rCfg.Enabled = false
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -88,7 +98,8 @@ func TestQueuedRetry_OnError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -114,7 +125,8 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -147,7 +159,8 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -176,7 +189,8 @@ func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -214,7 +228,8 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = 10 * time.Millisecond
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -245,7 +260,8 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg.QueueSize = 1
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -271,14 +287,15 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.QueueSize = 0
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
-	err := be.sender.send(newMockRequest(context.Background(), 2, errors.New("transient error")))
+	err = be.sender.send(newMockRequest(context.Background(), 2, errors.New("transient error")))
 	require.Error(t, err)
 }
 
@@ -289,7 +306,8 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -323,7 +341,8 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 0 // to make every request go straight to the queue
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be, err := newBaseExporter(&defaultExporterCfg, zap.NewNop(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), nopRequestUnmarshaler())
+	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
 	for i := 0; i < 7; i++ {
@@ -363,6 +382,10 @@ func (mer *mockErrorRequest) onError(error) request {
 	return mer
 }
 
+func (mer *mockErrorRequest) marshall() ([]byte, error) {
+	return nil, nil
+}
+
 func (mer *mockErrorRequest) count() int {
 	return 7
 }
@@ -392,6 +415,10 @@ func (m *mockRequest) export(ctx context.Context) error {
 	}
 	// Respond like gRPC/HTTP, if context is cancelled, return error
 	return ctx.Err()
+}
+
+func (m *mockRequest) marshall() ([]byte, error) {
+	return pdata.NewTraces().ToOtlpProtoBytes()
 }
 
 func (m *mockRequest) onError(error) request {

--- a/exporter/exporterhelper/wal.go
+++ b/exporter/exporterhelper/wal.go
@@ -1,0 +1,200 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/jaegertracing/jaeger/pkg/queue"
+	"github.com/nsqio/go-diskqueue"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+// WALQueue holds the WAL-backed queue
+type WALQueue struct {
+	logger      *zap.Logger
+	stopWG      sync.WaitGroup
+	unmarshaler requestUnmarshaler
+	wal         diskqueue.Interface
+	numWorkers  int
+	stopped     *atomic.Uint32
+	quit        chan struct{}
+	quitOnce    sync.Once
+}
+
+const (
+	// TODO: expose those as configuration parameters
+	maxBytesPerFile = int64(1 << 28)
+	minMsgSize      = int32(1)
+	maxMsgSize      = int32(1 << 27)
+	syncEvery       = int64(1000)
+)
+
+var (
+	errNotFound = errors.New("not found")
+)
+
+func dqLogOption(logger *zap.Logger, lvl diskqueue.LogLevel, f string, args ...interface{}) {
+	if logger == nil {
+		return
+	}
+
+	switch lvl {
+	case diskqueue.DEBUG:
+		logger.Debug(fmt.Sprintf(f, args...))
+	case diskqueue.INFO:
+		logger.Info(fmt.Sprintf(f, args...))
+	case diskqueue.WARN:
+		logger.Warn(fmt.Sprintf(f, args...))
+	case diskqueue.ERROR:
+		logger.Error(fmt.Sprintf(f, args...))
+	case diskqueue.FATAL:
+		logger.Fatal(fmt.Sprintf(f, args...))
+	}
+}
+
+func newWALQueue(logger *zap.Logger, path string, id string, syncFrequency time.Duration, unmarshaler requestUnmarshaler) (*WALQueue, error) {
+	syncOption := syncFrequency == 0
+	syncEveryOption := syncEvery
+	if syncOption {
+		syncEveryOption = 1
+		// FIXME: this must be always a positive number, lets figure out something nicer
+		syncFrequency = 1 * time.Second
+	}
+
+	walPath := filepath.Join(path, "wal")
+	err := os.MkdirAll(walPath, 0700)
+	if err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	// TODO: sanitize id?
+	_wal := diskqueue.New(id, walPath,
+		maxBytesPerFile, minMsgSize, maxMsgSize, syncEveryOption, syncFrequency,
+		func(lvl diskqueue.LogLevel, f string, args ...interface{}) {
+			dqLogOption(logger, lvl, f, args)
+		})
+
+	wq := &WALQueue{
+		logger:      logger,
+		wal:         _wal,
+		unmarshaler: unmarshaler,
+		stopped:     atomic.NewUint32(0),
+		quit:        make(chan struct{}),
+	}
+
+	return wq, nil
+}
+
+// StartConsumers starts the given number of consumers which will be consuming items
+func (wq *WALQueue) StartConsumers(num int, callback func(item interface{})) {
+	wq.numWorkers = num
+	var startWG sync.WaitGroup
+
+	factory := func() queue.Consumer {
+		return queue.ConsumerFunc(callback)
+	}
+
+	for i := 0; i < wq.numWorkers; i++ {
+		wq.stopWG.Add(1)
+		startWG.Add(1)
+		go func() {
+			startWG.Done()
+			defer wq.stopWG.Done()
+			consumer := factory()
+
+			for {
+				if wq.stopped.Load() != 0 {
+					return
+				}
+				req, err := wq.get()
+				if err == errNotFound || req == nil {
+					time.Sleep(1 * time.Second)
+				} else {
+					consumer.Consume(req)
+				}
+			}
+		}()
+	}
+	startWG.Wait()
+}
+
+// Produce adds an item to the queue and returns true if it was accepted
+func (wq *WALQueue) Produce(item interface{}) bool {
+	if wq.stopped.Load() != 0 {
+		return false
+	}
+
+	err := wq.put(item.(request))
+	return err == nil
+}
+
+// Stop stops accepting items and shuts-down the queue and closes the WAL
+func (wq *WALQueue) Stop() {
+	wq.logger.Debug("Stopping WAL")
+	wq.stopped.Store(1)
+	wq.quitOnce.Do(func() {
+		close(wq.quit)
+	})
+	wq.stopWG.Wait()
+	err := wq.close()
+	if err != nil {
+		wq.logger.Error("Error when closing WAL", zap.Error(err))
+	}
+}
+
+// Size returns the current depth of the queue
+func (wq *WALQueue) Size() int {
+	return int(wq.wal.Depth())
+}
+
+// put marshals the request and puts it into the WAL
+func (wq *WALQueue) put(req request) error {
+	bytes, err := req.marshall()
+	if err != nil {
+		return err
+	}
+
+	writeErr := wq.wal.Put(bytes)
+	if writeErr != nil {
+		return writeErr
+	}
+
+	return nil
+}
+
+// get returns the next request from the queue; note that it might be blocking if there are no entries in the WAL
+func (wq *WALQueue) get() (request, error) {
+	// TODO: Consider making it nonblocking, e.g. timeout after 1 second or so?
+	// ticker := time.NewTicker(1*time.Second)
+	// case <-ticker.C....
+
+	select {
+	case bytes := <-wq.wal.ReadChan():
+		return wq.unmarshaler(bytes)
+	case <-wq.quit:
+		return nil, nil
+	}
+}
+
+func (wq *WALQueue) close() error {
+	return wq.wal.Close()
+}

--- a/exporter/exporterhelper/wal_test.go
+++ b/exporter/exporterhelper/wal_test.go
@@ -1,0 +1,184 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func createTestQueue(path string) *WALQueue {
+	logger, _ := zap.NewDevelopment()
+
+	wq, err := newWALQueue(logger, path, "foo", 100*time.Millisecond, newTraceRequestUnmarshalerFunc(nopTracePusher()))
+	if err != nil {
+		panic(err)
+	}
+	return wq
+}
+
+func createTemporaryDirectory() string {
+	directory, err := ioutil.TempDir("", "wal-test")
+	if err != nil {
+		panic(err)
+	}
+	return directory
+}
+
+func TestWal_RepeatPutCloseReadClose(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	traces := newTraces(1, 10)
+	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+	for i := 0; i < 10; i++ {
+		wq := createTestQueue(path)
+		require.Equal(t, 0, wq.Size())
+		err := wq.put(req)
+		require.NoError(t, err)
+		err = wq.close()
+		require.NoError(t, err)
+
+		wq = createTestQueue(path)
+		require.Equal(t, 1, wq.Size())
+		readReq, err := wq.get()
+		require.NoError(t, err)
+		require.Equal(t, 0, wq.Size())
+		require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+		err = wq.close()
+		require.NoError(t, err)
+	}
+
+	// No more items
+	wq := createTestQueue(path)
+	require.Equal(t, 0, wq.Size())
+	wq.close()
+}
+
+func TestWal_ConsumersProducers(t *testing.T) {
+	cases := []struct {
+		numMessagesProduced int
+		numConsumers        int
+	}{
+		{
+			numMessagesProduced: 1,
+			numConsumers:        1,
+		},
+		{
+			numMessagesProduced: 100,
+			numConsumers:        1,
+		},
+		{
+			numMessagesProduced: 100,
+			numConsumers:        3,
+		},
+		{
+			numMessagesProduced: 1,
+			numConsumers:        100,
+		},
+		{
+			numMessagesProduced: 100,
+			numConsumers:        100,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("#messages: %d #consumers: %d", c.numMessagesProduced, c.numConsumers), func(t *testing.T) {
+			path := createTemporaryDirectory()
+			defer os.RemoveAll(path)
+
+			traces := newTraces(1, 10)
+			req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+			wq := createTestQueue(path)
+
+			numMessagesConsumed := 0
+			wq.StartConsumers(c.numConsumers, func(item interface{}) {
+				numMessagesConsumed++
+			})
+
+			for i := 0; i < c.numMessagesProduced; i++ {
+				wq.Produce(req)
+			}
+
+			// TODO: proper handling/wait with timeout rather than this
+			time.Sleep(500 * time.Millisecond)
+			wq.close()
+			require.Equal(t, c.numMessagesProduced, numMessagesConsumed)
+		})
+	}
+}
+
+func BenchmarkWal_1Trace10Spans(b *testing.B) {
+	path := createTemporaryDirectory()
+	wq := createTestQueue(path)
+	defer os.RemoveAll(path)
+
+	traces := newTraces(1, 10)
+	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := wq.put(req)
+		require.NoError(b, err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		req, err := wq.get()
+		require.NoError(b, err)
+		require.NotNil(b, req)
+	}
+
+	wq.close()
+}
+
+func newTraces(numTraces int, numSpans int) pdata.Traces {
+	traces := pdata.NewTraces()
+	batch := traces.ResourceSpans().AppendEmpty()
+	batch.Resource().Attributes().InsertString("resource-attr", "some-resource")
+	batch.Resource().Attributes().InsertInt("num-traces", int64(numTraces))
+	batch.Resource().Attributes().InsertInt("num-spans", int64(numSpans))
+
+	for i := 0; i < numTraces; i++ {
+		traceID := pdata.NewTraceID([16]byte{1, 2, 3, byte(i)})
+		ils := batch.InstrumentationLibrarySpans().AppendEmpty()
+		for j := 0; j < numSpans; j++ {
+			span := ils.Spans().AppendEmpty()
+			span.SetTraceID(traceID)
+			span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, byte(j)}))
+			span.SetName("should-not-be-changed")
+			span.Attributes().InsertInt("int-attribute", int64(j))
+			span.Attributes().InsertString("str-attribute-1", "foobar")
+			span.Attributes().InsertString("str-attribute-2", "fdslafjasdk12312312jkl")
+			span.Attributes().InsertString("str-attribute-3", "AbcDefGeKKjkfdsafasdfsdasdf")
+			span.Attributes().InsertString("str-attribute-4", "xxxxxx")
+			span.Attributes().InsertString("str-attribute-5", "abcdef")
+		}
+	}
+
+	return traces
+}

--- a/exporter/jaegerexporter/config_test.go
+++ b/exporter/jaegerexporter/config_test.go
@@ -60,9 +60,10 @@ func TestLoadConfig(t *testing.T) {
 				MaxElapsedTime:  10 * time.Minute,
 			},
 			QueueSettings: exporterhelper.QueueSettings{
-				Enabled:      true,
-				NumConsumers: 2,
-				QueueSize:    10,
+				Enabled:          true,
+				NumConsumers:     2,
+				QueueSize:        10,
+				WalSyncFrequency: 1 * time.Second,
 			},
 			GRPCClientSettings: configgrpc.GRPCClientSettings{
 				Endpoint:        "a.new.target:1234",

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -51,9 +51,10 @@ func TestLoadConfig(t *testing.T) {
 			MaxElapsedTime:  10 * time.Minute,
 		},
 		QueueSettings: exporterhelper.QueueSettings{
-			Enabled:      true,
-			NumConsumers: 2,
-			QueueSize:    10,
+			Enabled:          true,
+			NumConsumers:     2,
+			QueueSize:        10,
+			WalSyncFrequency: 1 * time.Second,
 		},
 		Topic:    "spans",
 		Encoding: "otlp_proto",

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -58,9 +58,10 @@ func TestLoadConfig(t *testing.T) {
 				MaxElapsedTime:  10 * time.Minute,
 			},
 			QueueSettings: exporterhelper.QueueSettings{
-				Enabled:      true,
-				NumConsumers: 2,
-				QueueSize:    10,
+				Enabled:          true,
+				NumConsumers:     2,
+				QueueSize:        10,
+				WalSyncFrequency: 1 * time.Second,
 			},
 			GRPCClientSettings: configgrpc.GRPCClientSettings{
 				Headers: map[string]string{

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -55,9 +55,10 @@ func TestLoadConfig(t *testing.T) {
 				MaxElapsedTime:  10 * time.Minute,
 			},
 			QueueSettings: exporterhelper.QueueSettings{
-				Enabled:      true,
-				NumConsumers: 2,
-				QueueSize:    10,
+				Enabled:          true,
+				NumConsumers:     2,
+				QueueSize:        10,
+				WalSyncFrequency: 1 * time.Second,
 			},
 			HTTPClientSettings: confighttp.HTTPClientSettings{
 				Headers: map[string]string{

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -61,9 +61,10 @@ func TestLoadConfig(t *testing.T) {
 			MaxElapsedTime:  10 * time.Minute,
 		},
 		QueueSettings: exporterhelper.QueueSettings{
-			Enabled:      true,
-			NumConsumers: 2,
-			QueueSize:    10,
+			Enabled:          true,
+			NumConsumers:     2,
+			QueueSize:        10,
+			WalSyncFrequency: 1 * time.Second,
 		},
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint:        "https://somedest:1234/api/v2/spans",

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/jaegertracing/jaeger v1.22.0
 	github.com/leoluk/perflib_exporter v0.1.0
+	github.com/nsqio/go-diskqueue v1.0.0
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -758,6 +758,8 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nsqio/go-diskqueue v1.0.0 h1:XRqpx7zTMu9yNVH+cHvA5jEiPNKoYcyEsCVqXP3eFg4=
+github.com/nsqio/go-diskqueue v1.0.0/go.mod h1:INuJIxl4ayUsyoNtHL5+9MFPDfSZ0zY93hNY6vhBRsI=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=


### PR DESCRIPTION
**Description:**

Draft WAL queued_retry support implementation

It leverages [bounded_queue](https://github.com/jaegertracing/jaeger/blob/master/pkg/queue/bounded_queue.go) interface and uses [go-diskqueue](https://github.com/nsqio/go-diskqueue) to back WAL implementation.